### PR TITLE
Support for IDA 9.0 and other bug fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vs
+classinformer-code/x64/
+classinformer-code/Plugin/x64/
+classinformer-code/Plugin/GeneratedFiles

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# classinformer-ida8
-IDA Class Informer plugin for IDA 8.x
+# Class Informer
+IDA Class Informer plugin for IDA Pro 9 and older versions.
 
-Changelog from the original [IDA ClassInformer PlugIn v2.6](https://sourceforge.net/projects/classinformer/)
-- Updated to IDA SDK 8.2 and MSVC 2019
-- Updated the plugin form to the new one to work with IDA SDK 8.2
-- Created a plugin to analyze PE32 on IDA 64 (IDA_ClassInformer_PlugIn3264.dlL) because IDA is currently stopping to use IDA for 32-bit.
-- Linked VC++ runtime statically (/MT*)
+ - This plugin has been tested with IDA Pro `9.0 Beta`, `7.7` and `8.3`, both 32-bit and 64-bit versions.
+ - You no longer need a separate version of the plugin for working on 32-bit files in 64-bit IDA.
+ - For IDA 9, you just need to install `ClassInformer64.dll`.
+ - For IDA 8 and 7, you need to install both `ClassInformer64.dll` and `ClassInformer.dll`.
 
 ## Download
 - You can download compiled binaries from the [Releases](../../releases) section.

--- a/classinformer-code/IDA_ClassInformer.sln
+++ b/classinformer-code/IDA_ClassInformer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33214.272
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PlugIn", "Plugin\IDA_ClassInformer_PlugIn.vcxproj", "{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}"
 EndProject
@@ -11,7 +11,6 @@ Global
 		Debug64|x64 = Debug64|x64
 		Release|x64 = Release|x64
 		Release64|x64 = Release64|x64
-		Release6432|x64 = Release6432|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}.Debug|x64.ActiveCfg = Debug|x64
@@ -22,8 +21,6 @@ Global
 		{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}.Release|x64.Build.0 = Release|x64
 		{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}.Release64|x64.ActiveCfg = Release64|x64
 		{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}.Release64|x64.Build.0 = Release64|x64
-		{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}.Release6432|x64.ActiveCfg = Release3264|x64
-		{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}.Release6432|x64.Build.0 = Release3264|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/classinformer-code/Plugin/Class_Informer.txt
+++ b/classinformer-code/Plugin/Class_Informer.txt
@@ -1,3 +1,14 @@
+Class Informer for IDA 9:
+===========================================================
+IDA Pro class vftable finder, namer, fixer, lister plug-in.
+Version 2.9, August 2024
+By Rohitab Batra
+
+https://github.com/rohitab/ClassInformer
+
+Source code is backwards compatible with IDA 8 and 7.
+Version 2.8 was the initial release with support for IDA 9.
+
 
 Class Informer for IDA 8:
 ===========================================================

--- a/classinformer-code/Plugin/IDA_ClassInformer_PlugIn.vcxproj
+++ b/classinformer-code/Plugin/IDA_ClassInformer_PlugIn.vcxproj
@@ -9,10 +9,6 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release3264|x64">
-      <Configuration>Release3264</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Release64|x64">
       <Configuration>Release64</Configuration>
       <Platform>x64</Platform>
@@ -24,38 +20,32 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>PlugIn</ProjectName>
-    <Keyword>Qt4VSv1.0</Keyword>
+    <Keyword>QtVS_v304</Keyword>
     <ProjectGuid>{DEADBEEF-CAFE-F00D-FEED-C0FFEEC0FFEE}</ProjectGuid>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <UseOfMfc>false</UseOfMfc>
-    <CharacterSet>NotSet</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
@@ -82,11 +72,6 @@
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
     <Import Project="PropertySheet.props" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
-    <Import Project="PropertySheet.props" />
-  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>12.0.30501.0</_ProjectFileVersion>
@@ -95,36 +80,25 @@
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <TargetExt>.dlL</TargetExt>
-    <TargetName>IDA_ClassInformer_PlugIn</TargetName>
+    <TargetName>ClassInformer</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <TargetExt>.dlL</TargetExt>
-    <TargetName>IDA_ClassInformer_PlugIn64</TargetName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-    <IgnoreImportLibrary>true</IgnoreImportLibrary>
-    <LinkIncremental>false</LinkIncremental>
-    <GenerateManifest>false</GenerateManifest>
-    <TargetExt>.dlL</TargetExt>
-    <TargetName>IDA_ClassInformer_PlugIn3264</TargetName>
+    <TargetName>ClassInformer64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <TargetExt>.dlL</TargetExt>
-    <TargetName>IDA_ClassInformer_PlugInd</TargetName>
+    <TargetName>ClassInformer</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <TargetExt>.dlL</TargetExt>
-    <TargetName>IDA_ClassInformer_PlugIn64d</TargetName>
+    <TargetName>ClassInformer64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Midl>
@@ -166,7 +140,7 @@
       <AdditionalDependencies>ida.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_32;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_32_pro;$(IDASDK)lib\x64_win_vc_32;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
@@ -183,9 +157,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <OutputFile>$(SolutionDir)Release\IDA_RTTI_Informer_PlugIn.bsc</OutputFile>
     </Bscmake>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetFileName) $(SolutionDir)</Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
     <Midl>
@@ -227,7 +199,7 @@
       <AdditionalDependencies>ida.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_64;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_64_pro;$(IDASDK)lib\x64_win_vc_64;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
@@ -244,70 +216,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <OutputFile>$(SolutionDir)Release\IDA_RTTI_Informer_PlugIn.bsc</OutputFile>
     </Bscmake>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetFileName) $(SolutionDir)</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-    <Midl>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MkTypLibCompatible>true</MkTypLibCompatible>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TypeLibraryName>.\Release/IDA_RTTI_Informer_PlugIn.tlb</TypeLibraryName>
-      <HeaderFileName>
-      </HeaderFileName>
-    </Midl>
-    <ClCompile>
-      <Optimization>Full</Optimization>
-      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <AdditionalIncludeDirectories>.;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);$(IDASDK)include;$(QTDIR)include;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;$(IDASUPPORT)SupportLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__X64__;__EA64__;__EA3264__;NDEBUG;_WINDOWS;_USRDLL;__NT__;__IDP__;__VC__;QT_NO_DEBUG;QT_NAMESPACE=QT;QT_NO_UNICODE_LITERAL;MATERIAL_DESIGN_STYLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <StringPooling>true</StringPooling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
-      <FunctionLevelLinking>false</FunctionLevelLinking>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AssemblerOutput>NoListing</AssemblerOutput>
-      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
-      <ObjectFileName>$(IntDir)</ObjectFileName>
-      <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
-      <WarningLevel>Level3</WarningLevel>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <CallingConvention>Cdecl</CallingConvention>
-      <ExceptionHandling>Async</ExceptionHandling>
-    </ClCompile>
-    <ResourceCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <Culture>0x0409</Culture>
-    </ResourceCompile>
-    <Link>
-      <AdditionalDependencies>ida.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_64;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <ProgramDatabaseFile>
-      </ProgramDatabaseFile>
-      <SubSystem>Windows</SubSystem>
-      <OptimizeReferences>true</OptimizeReferences>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <RandomizedBaseAddress>false</RandomizedBaseAddress>
-      <DataExecutionPrevention>
-      </DataExecutionPrevention>
-      <ImportLibrary>
-      </ImportLibrary>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-    </Link>
-    <Bscmake>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <OutputFile>$(SolutionDir)Release\IDA_RTTI_Informer_PlugIn.bsc</OutputFile>
-    </Bscmake>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetFileName) $(SolutionDir)</Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Midl>
@@ -343,7 +252,7 @@
       <AdditionalDependencies>ida.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_32;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_32_pro;$(IDASDK)lib\x64_win_vc_32;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
@@ -358,9 +267,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <OutputFile>$(SolutionDir)Debug\IDA_RTTI_Informer_PlugIn.bsc</OutputFile>
     </Bscmake>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetFileName) $(SolutionDir)</Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">
     <Midl>
@@ -396,7 +303,7 @@
       <AdditionalDependencies>ida.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_64;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)lib\x64_win_vc_64_pro;$(IDASDK)lib\x64_win_vc_64;$(IDASDK)lib\x64_win_qt;$(IDASUPPORT)IDA_WaitEx;$(IDASUPPORT)IDA_SegmentSelect;$(IDASUPPORT)IDA_OggPlayer;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
@@ -411,9 +318,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <OutputFile>$(SolutionDir)Debug\IDA_RTTI_Informer_PlugIn.bsc</OutputFile>
     </Bscmake>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetFileName) $(SolutionDir)</Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="RTTI.h">
@@ -435,22 +340,15 @@
       </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Performing Custom Build Tools</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Performing Custom Build Tools</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Performing Custom Build Tools</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
-      </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
       </AdditionalInputs>
     </CustomBuild>
     <CustomBuild Include="StdAfx.h">
@@ -472,22 +370,15 @@
       </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Performing Custom Build Tools</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Performing Custom Build Tools</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Performing Custom Build Tools</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
-      </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
       </AdditionalInputs>
     </CustomBuild>
     <CustomBuild Include="undname.h">
@@ -509,22 +400,15 @@
       </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Performing Custom Build Tools</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Performing Custom Build Tools</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Performing Custom Build Tools</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
-      </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
       </AdditionalInputs>
     </CustomBuild>
     <CustomBuild Include="Vftable.h">
@@ -546,22 +430,15 @@
       </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Performing Custom Build Tools</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Performing Custom Build Tools</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Performing Custom Build Tools</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
-      </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
       </AdditionalInputs>
     </CustomBuild>
   </ItemGroup>
@@ -571,14 +448,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">false</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="GeneratedFiles\Debug\moc_MainDialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="GeneratedFiles\qrc_ClassInformerRes.cpp">
@@ -590,29 +465,24 @@
       </PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">
       </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-      </PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="GeneratedFiles\Release64\moc_MainDialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="GeneratedFiles\Release\moc_MainDialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="GeneratedFiles\Release3264\moc_MainDialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">false</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MainDialog.cpp" />
@@ -631,16 +501,12 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">"$(QTDIR)bin\uic.exe" -o ".\GeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">$(QTDIR)bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">$(QTDIR)bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Uic%27ing %(Identity)...</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Uic%27ing %(Identity)...</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Uic%27ing %(Identity)...</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">.\GeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">.\GeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)bin\uic.exe" -o ".\GeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">"$(QTDIR)bin\uic.exe" -o ".\GeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">"$(QTDIR)bin\uic.exe" -o ".\GeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -656,18 +522,14 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">"$(QTDIR)bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_DEVMODE -D__EA64__ -D__X64__ -D_DEBUG -D_WINDOWS -D_USRDLL -D__NT__ -D__IDP__ -D__VC__ -DQT_NO_DEBUG -DQT_NAMESPACE=QT -DQT_NO_UNICODE_LITERAL -D_CRT_SECURE_NO_WARNINGS -DMATERIAL_DESIGN_STYLE -D_VC80_UPGRADE=0x0600 -D_WINDLL  "-I." "-I.\GeneratedFiles" "-I.\GeneratedFiles\$(ConfigurationName)\." "-I$(_IDADIR)\idasdk\include" "-I$(QTDIR)include" "-I$(IDASUPPORT)\IDA_WaitEx" "-I$(IDASUPPORT)\IDA_SegmentSelect" "-I$(IDASUPPORT)\IDA_OggPlayer" "-I$(IDASUPPORT)\SupportLib"</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing MainDialog.h...</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Moc%27ing MainDialog.h...</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Moc%27ing MainDialog.h...</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D__X64__ -DNDEBUG -D_WINDOWS -D_USRDLL -D__NT__ -D__IDP__ -D__VC__ -DQT_NO_DEBUG -DQT_NAMESPACE=QT -DQT_NO_UNICODE_LITERAL -DMATERIAL_DESIGN_STYLE -D_CRT_SECURE_NO_WARNINGS -D_VC80_UPGRADE=0x0600 -D_WINDLL  "-I." "-I.\GeneratedFiles" "-I.\GeneratedFiles\$(ConfigurationName)\." "-I$(_IDADIR)\idasdk\include" "-I$(QTDIR)include" "-I$(IDASUPPORT)\IDA_WaitEx" "-I$(IDASUPPORT)\IDA_SegmentSelect" "-I$(IDASUPPORT)\IDA_OggPlayer" "-I$(IDASUPPORT)\SupportLib"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">"$(QTDIR)bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D__X64__ -D__EA64__ -DNDEBUG -D_WINDOWS -D_USRDLL -D__NT__ -D__IDP__ -D__VC__ -DQT_NO_DEBUG -DQT_NAMESPACE=QT -DQT_NO_UNICODE_LITERAL -DMATERIAL_DESIGN_STYLE -D_CRT_SECURE_NO_WARNINGS -D_VC80_UPGRADE=0x0600 -D_WINDLL  "-I." "-I.\GeneratedFiles" "-I.\GeneratedFiles\$(ConfigurationName)\." "-I$(_IDADIR)\idasdk\include" "-I$(QTDIR)include" "-I$(IDASUPPORT)\IDA_WaitEx" "-I$(IDASUPPORT)\IDA_SegmentSelect" "-I$(IDASUPPORT)\IDA_OggPlayer" "-I$(IDASUPPORT)\SupportLib"</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">"$(QTDIR)bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D__X64__ -D__EA64__ -DNDEBUG -D_WINDOWS -D_USRDLL -D__NT__ -D__IDP__ -D__VC__ -DQT_NO_DEBUG -DQT_NAMESPACE=QT -DQT_NO_UNICODE_LITERAL -DMATERIAL_DESIGN_STYLE -D_CRT_SECURE_NO_WARNINGS -D_VC80_UPGRADE=0x0600 -D_WINDLL  "-I." "-I.\GeneratedFiles" "-I.\GeneratedFiles\$(ConfigurationName)\." "-I$(_IDADIR)\idasdk\include" "-I$(QTDIR)include" "-I$(IDASUPPORT)\IDA_WaitEx" "-I$(IDASUPPORT)\IDA_SegmentSelect" "-I$(IDASUPPORT)\IDA_OggPlayer" "-I$(IDASUPPORT)\SupportLib"</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -682,16 +544,12 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">"$(QTDIR)bin\rcc.exe" -name "%(Filename)" -no-compress "%(FullPath)" -o .\GeneratedFiles\qrc_%(Filename).cpp</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(FullPath);.\banner.png;.\icon.png;.\completed.ogg;.\checkbox-checked.png;.\progress-style.qss;.\style.qss;.\view-style.qss;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">%(FullPath);.\banner.png;.\icon.png;.\completed.ogg;.\checkbox-checked.png;.\progress-style.qss;.\style.qss;.\view-style.qss;%(AdditionalInputs)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">%(FullPath);.\banner.png;.\icon.png;.\completed.ogg;.\checkbox-checked.png;.\progress-style.qss;.\style.qss;.\view-style.qss;%(AdditionalInputs)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Rcc%27ing %(Identity)...</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">Rcc%27ing %(Identity)...</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">Rcc%27ing %(Identity)...</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\qrc_%(Filename).cpp;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">.\GeneratedFiles\qrc_%(Filename).cpp;%(Outputs)</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">.\GeneratedFiles\qrc_%(Filename).cpp;%(Outputs)</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)bin\rcc.exe" -name "%(Filename)" -no-compress "%(FullPath)" -o .\GeneratedFiles\qrc_%(Filename).cpp</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">"$(QTDIR)bin\rcc.exe" -name "%(Filename)" -no-compress "%(FullPath)" -o .\GeneratedFiles\qrc_%(Filename).cpp</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">"$(QTDIR)bin\rcc.exe" -name "%(Filename)" -no-compress "%(FullPath)" -o .\GeneratedFiles\qrc_%(Filename).cpp</Command>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -700,7 +558,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
     </None>
     <None Include="progress-style.qss" />
     <None Include="style.qss" />
@@ -712,32 +569,22 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
     </Image>
     <Image Include="checkbox-checked.png">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
     </Image>
     <Image Include="icon.png">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">true</ExcludedFromBuild>
     </Image>
   </ItemGroup>
   <ItemGroup>
     <Text Include="Class_Informer.txt" />
-    <Text Include="Doc\classes.txt" />
-    <Text Include="Doc\List Window Child Widgets.txt" />
-    <Text Include="Doc\Notes.txt" />
-    <Text Include="Doc\Qt Build and MOC stuff.txt" />
-    <Text Include="Doc\ScratchPad.txt" />
-    <Text Include="Doc\Temp.txt" />
-    <Text Include="Doc\Update TODO.txt" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/classinformer-code/Plugin/IDA_ClassInformer_PlugIn.vcxproj.filters
+++ b/classinformer-code/Plugin/IDA_ClassInformer_PlugIn.vcxproj.filters
@@ -125,27 +125,6 @@
     </Image>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="Doc\classes.txt">
-      <Filter>Doc</Filter>
-    </Text>
-    <Text Include="Doc\List Window Child Widgets.txt">
-      <Filter>Doc</Filter>
-    </Text>
-    <Text Include="Doc\Notes.txt">
-      <Filter>Doc</Filter>
-    </Text>
-    <Text Include="Doc\Qt Build and MOC stuff.txt">
-      <Filter>Doc</Filter>
-    </Text>
-    <Text Include="Doc\ScratchPad.txt">
-      <Filter>Doc</Filter>
-    </Text>
-    <Text Include="Doc\Temp.txt">
-      <Filter>Doc</Filter>
-    </Text>
-    <Text Include="Doc\Update TODO.txt">
-      <Filter>Doc</Filter>
-    </Text>
     <Text Include="Class_Informer.txt">
       <Filter>Doc</Filter>
     </Text>

--- a/classinformer-code/Plugin/IDA_ClassInformer_PlugIn.vcxproj.user
+++ b/classinformer-code/Plugin/IDA_ClassInformer_PlugIn.vcxproj.user
@@ -20,9 +20,4 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerEnvironment>PATH=$(QTDIR)bin%3b$(PATH)</LocalDebuggerEnvironment>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release3264|x64'">
-    <LocalDebuggerCommand>$(IDADIR)ida64.exe </LocalDebuggerCommand>
-    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerEnvironment>PATH=$(QTDIR)bin%3b$(PATH)</LocalDebuggerEnvironment>
-  </PropertyGroup>
 </Project>

--- a/classinformer-code/Plugin/Main.h
+++ b/classinformer-code/Plugin/Main.h
@@ -40,27 +40,26 @@ template <class T> BOOL getVerify32(ea_t eaPtr, T &rValue)
 	return(FALSE);
 }
 
+#if IDA_SDK_VERSION < 800
+#define EA_SIZE sizeof(ea_t)
+#else
+#define EA_SIZE EAH.ea_size
+#endif
+
+extern BOOL isDatabase64Bit;
+
 // Get address/pointer value
 inline ea_t getEa(ea_t ea)
 {
-    //#ifndef __EA64__
-    #if !defined(__EA64__) || defined(__EA3264__) 
-    return((ea_t) get_32bit(ea));
-    #else
-    return((ea_t) get_64bit(ea));
-    #endif
+    return isDatabase64Bit ? get_64bit(ea) : get_32bit(ea);
 }
 
 
 // Returns TRUE if ea_t sized value flags
 inline BOOL isEa(flags_t f)
 {
-    //#ifndef __EA64__
-    #if !defined(__EA64__) || defined(__EA3264__) 
-    return(is_dword(f));
-    #else
-    return(is_qword(f));
-    #endif
+    return isDatabase64Bit ? is_qword(f) : is_dword(f);
 }
 
 extern BOOL optionPlaceStructs;
+extern BOOL optionPlaceAtNamed;

--- a/classinformer-code/Plugin/MainDialog.cpp
+++ b/classinformer-code/Plugin/MainDialog.cpp
@@ -5,6 +5,7 @@
 //
 // ****************************************************************************
 #include "stdafx.h"
+#include "Main.h"
 #include "MainDialog.h"
 
 #include <QtWidgets/QDialogButtonBox>
@@ -19,6 +20,7 @@ MainDialog::MainDialog(BOOL& optionPlaceStructs, BOOL& optionProcessStatic, BOOL
 
     #define INITSTATE(obj,state) obj->setCheckState((state == TRUE) ? Qt::Checked : Qt::Unchecked);
     INITSTATE(checkBox1, optionPlaceStructs);
+    INITSTATE(checkBoxAtNamed, optionPlaceAtNamed);
     INITSTATE(checkBox2, optionProcessStatic);
     INITSTATE(checkBox3, optionAudioOnDone);
     #undef INITSTATE
@@ -46,6 +48,7 @@ BOOL doMainDialog(BOOL &optionPlaceStructs, BOOL &optionProcessStatic, BOOL &opt
     {
         #define CHECKSTATE(obj,var) var = dlg->obj->isChecked()
         CHECKSTATE(checkBox1, optionPlaceStructs);
+        CHECKSTATE(checkBoxAtNamed, optionPlaceAtNamed);
         CHECKSTATE(checkBox2, optionProcessStatic);
         CHECKSTATE(checkBox3, optionAudioOnDone);
         #undef CHECKSTATE

--- a/classinformer-code/Plugin/PropertySheet.props
+++ b/classinformer-code/Plugin/PropertySheet.props
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <IDADIR>C:\Program Files\IDA Pro 8.2\</IDADIR>
-    <QTDIR>C:\Qt\5.15.2-x64\</QTDIR>
+    <IDADIR>C:\Program Files\IDA Professional 9.0\</IDADIR>
+    <QTDIR>C:\Qt\Qt-5.15.3\</QTDIR>
     <IDASUPPORT>..\..\ida-support-library-code\</IDASUPPORT>
-    <IDASDK>..\..\idasdk_pro82\</IDASDK>
+    <IDASDK>$(IDADIR)\sdk\</IDASDK>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />

--- a/classinformer-code/Plugin/StdAfx.h
+++ b/classinformer-code/Plugin/StdAfx.h
@@ -28,7 +28,9 @@
 #include <loader.hpp>
 #include <search.hpp>
 #include <typeinf.hpp>
+#if IDA_SDK_VERSION < 900
 #include <struct.hpp>
+#endif
 #include <nalt.hpp>
 #include <demangle.hpp>
 #pragma warning(pop)
@@ -67,4 +69,4 @@ typedef std::unordered_map<ea_t, UINT> eaRefMap; // address & ref count
 //#define STYLE_PATH "C:/Projects/IDA Pro Work/IDA_ClassInformer_PlugIn/Plugin/"
 #define STYLE_PATH ":/classinf/"
 
-#define MY_VERSION MAKEWORD(7, 2) // Low, high, convention: 0 to 99
+#define MY_VERSION MAKEWORD(9, 2) // Low, high, convention: 0 to 99

--- a/classinformer-code/Plugin/Vftable.cpp
+++ b/classinformer-code/Plugin/Vftable.cpp
@@ -101,11 +101,11 @@ BOOL vftable::getTableInfo(ea_t ea, vtinfo &info)
             fixEa(ea);
             fixFunction(memberPtr);
 
-            ea += sizeof(ea_t);
+            ea += EA_SIZE;
         };
 
         // Reached the presumed end of it
-        if ((info.methodCount = ((ea - start) / sizeof(ea_t))) > 0)
+        if ((info.methodCount = ((ea - start) / EA_SIZE)) > 0)
         {
             info.end = ea;
             //msg(" vftable: "EAFORMAT"-"EAFORMAT", methods: %d\n", rtInfo.eaStart, rtInfo.eaEnd, rtInfo.uMethods);

--- a/classinformer-code/Plugin/dialog.ui
+++ b/classinformer-code/Plugin/dialog.ui
@@ -79,7 +79,29 @@
     <string notr="true"/>
    </property>
    <property name="text">
-    <string>Place structures</string>
+    <string>&amp;Place structures</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="checkBoxAtNamed">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>94</y>
+     <width>137</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <family>Noto Sans</family>
+     <pointsize>10</pointsize>
+    </font>
+   </property>
+   <property name="toolTip">
+    <string notr="true"/>
+   </property>
+   <property name="text">
+    <string>at &amp;named locations</string>
    </property>
   </widget>
   <widget class="QCheckBox" name="checkBox2">
@@ -101,7 +123,7 @@
     <string notr="true"/>
    </property>
    <property name="text">
-    <string>Process static initializers &amp;&amp; terminators</string>
+    <string>Process static &amp;initializers &amp;&amp; terminators</string>
    </property>
   </widget>
   <widget class="QCheckBox" name="checkBox3">
@@ -123,7 +145,7 @@
     <string notr="true"/>
    </property>
    <property name="text">
-    <string>Audio on completion</string>
+    <string>&amp;Audio on completion</string>
    </property>
   </widget>
   <widget class="QLabel" name="linkLabel">
@@ -131,8 +153,8 @@
     <rect>
      <x>15</x>
      <y>225</y>
-     <width>141</width>
-     <height>16</height>
+     <width>106</width>
+     <height>18</height>
     </rect>
    </property>
    <property name="font">
@@ -145,7 +167,7 @@
     <enum>QFrame::Sunken</enum>
    </property>
    <property name="text">
-    <string>&lt;a href=&quot;http://www.macromonkey.com/bb/index.php/topic,13.0.html&quot; style=&quot;color:#AA00FF;&quot;&gt;Class Informer Fourm&lt;/a&gt;</string>
+    <string>&lt;a href=&quot;https://github.com/rohitab/ClassInformer&quot; style=&quot;color:#AA00FF;&quot;&gt;Source on GitHub&lt;/a&gt;</string>
    </property>
    <property name="textFormat">
     <enum>Qt::AutoText</enum>
@@ -182,10 +204,10 @@
   <widget class="QLabel" name="versionLabel">
    <property name="geometry">
     <rect>
-     <x>225</x>
-     <y>44</y>
-     <width>61</width>
-     <height>24</height>
+     <x>205</x>
+     <y>6</y>
+     <width>81</width>
+     <height>61</height>
     </rect>
    </property>
    <property name="font">
@@ -198,8 +220,10 @@
     <string notr="true"/>
    </property>
    <property name="text">
-    <string>Version: 2.7
-By Hiroshi Suzuki (By Sirmabus originally)</string>
+    <string>Version: 2.9
+By Rohitab Batra
+By Hiroshi Suzuki
+By Sirmabus</string>
    </property>
    <property name="textFormat">
     <enum>Qt::PlainText</enum>
@@ -227,7 +251,7 @@ By Hiroshi Suzuki (By Sirmabus originally)</string>
     <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optionally select wich segments to scan for strings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
    <property name="text">
-    <string notr="true">SELECT SEGMENTS</string>
+    <string notr="true">SELECT &amp;SEGMENTS</string>
    </property>
    <property name="autoDefault">
     <bool>false</bool>

--- a/classinformer-code/Plugin/view-style.qss
+++ b/classinformer-code/Plugin/view-style.qss
@@ -10,7 +10,12 @@ QTableView
 {
 	font-family: Noto Sans,Consolas;
 	font-weight: 100;
-	font-size: 14px;
+	font-size: 12px;
+}
+
+QTableView::item
+{
+	padding-right: 12px;
 }
 
 /* Color the status bar */

--- a/ida-support-library-code/SupportLib/Utility.cpp
+++ b/ida-support-library-code/SupportLib/Utility.cpp
@@ -209,7 +209,11 @@ ea_t find_binary2(ea_t start_ea, ea_t end_ea, LPCSTR pattern, LPCSTR file, int l
 	compiled_binpat_vec_t searchVec;	
 	qstring errorStr;
 	if (parse_binpat_str(&searchVec, start_ea, pattern, 16, PBSENC_DEF1BPU, &errorStr))	
-		return bin_search2(start_ea, end_ea, searchVec, (BIN_SEARCH_FORWARD | BIN_SEARCH_NOBREAK | BIN_SEARCH_NOSHOW));	
+#if IDA_SDK_VERSION >= 900
+		return bin_search3(start_ea, end_ea, searchVec, (BIN_SEARCH_FORWARD | BIN_SEARCH_NOBREAK | BIN_SEARCH_NOSHOW));
+#else
+		return bin_search2(start_ea, end_ea, searchVec, (BIN_SEARCH_FORWARD | BIN_SEARCH_NOBREAK | BIN_SEARCH_NOSHOW));
+#endif
 	else
 		msg("** parse_binpat_str() failed! Reason: \"%s\" @ %s, line #%d **", errorStr.c_str(), __FILE__, __LINE__);
 	return BADADDR;
@@ -250,7 +254,6 @@ ea_t find_binary2(ea_t start_ea, ea_t end_ea, LPCSTR pattern, LPCSTR file, int l
 #define FF_FUNC 0x10000000LU	// Function start
 //              0x20000000LU    // Reserved
 #define FF_IMMD 0x40000000LU    // Has Immediate value
-#define FF_JUMP 0x80000000LU    // Has jump table or switch_info
 
 // * Instruction/Data operands 0F000000
 #define MS_1TYPE 0x0F000000LU   // Mask for the type of other operands
@@ -300,7 +303,7 @@ ea_t find_binary2(ea_t start_ea, ea_t end_ea, LPCSTR pattern, LPCSTR file, int l
 #define FF_IVL  0x00000100LU	// Has byte value in 000000FF
 
 // Decode IDA address flags value into a readable string
-#if !defined(__EA64__)
+#if !defined(__EA64__) || IDA_SDK_VERSION < 800
 void idaFlags2String(flags_t f, __out qstring &s, BOOL withValue)
 #else
 void idaFlags2String(flags64_t f, __out qstring &s, BOOL withValue)


### PR DESCRIPTION
 * Add support for IDA 9.0, while maintaining backward compatibility.
 * Combine 64-bit version and PE32 on 64-bit version into a single DLL.
 * Add option to allow structures to be placed at named locations.
 * Add accelerators/hotkeys to Class Informer dialog.
 * Change representation of "name" field in type descriptor to string.
 * Rename "IDA_ClassInformer_PlugIn64.dlL" to "ClassInformer64.dll"
 * Fix issue: ** customizeChooseWindow(): "IDADockWidget" not found!
 * Fix issue where CSS style sheet was not being applied.
 * Fix issue: ** customizeChooseWindow(): "TChooserView" not found!
 * Fix issue where row height and sort order were not being applied.
 * Auto size all columns to fit and stretch the last column.
 * Automatically select the first row when Class Informer is run.
 * Fix issue: * Already active. Please close the chooser window first to run it again.
 * Activate existing Class Informer window if it's already open.
 * Retain settings from previous runs in the current database/instance.
 * Reduce font size from 14 to 12px and reduce row height from 24 to 22.
 * Add padding to columns.
 * Update credits and documentation.
 * Class Informer version is now 2.9.